### PR TITLE
refactor: apply removeHtmlTags() method on mapper

### DIFF
--- a/lib/data/mapper/content_detail_info_mapper.dart
+++ b/lib/data/mapper/content_detail_info_mapper.dart
@@ -1,4 +1,5 @@
 import 'package:kovel_app/core/enums/content_type.dart';
+import 'package:kovel_app/core/utils/html_util.dart';
 import 'package:kovel_app/data/dto/content_detail_info_dto.dart';
 import 'package:kovel_app/domain/model/detail/course/course_detail_info.dart';
 import 'package:kovel_app/domain/model/detail/culture_location/culture_location_detail_info.dart';
@@ -9,48 +10,48 @@ import 'package:kovel_app/domain/model/detail/tourist_spot/tourist_spot_detail_i
 extension ToContentDetailInfo on ContentDetailInfoDto {
   CourseDetailInfo toCourseDetailInfo() {
     return CourseDetailInfo(
-        contentId: int.tryParse(contentid!) ?? 0,
-        contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
-        subContentId: int.tryParse(subcontentid!) ?? 0,
-        name: subname ?? '',
-        overview: subdetailoverview ?? '',
-        imagePath: subdetailimg ?? '',
+      contentId: int.tryParse(contentid!) ?? 0,
+      contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
+      subContentId: int.tryParse(subcontentid!) ?? 0,
+      name: subname ?? '',
+      overview: subdetailoverview ?? '',
+      imagePath: subdetailimg ?? '',
     );
   }
 
   CultureLocationDetailInfo toCultureLocationDeteailInfo() {
     return CultureLocationDetailInfo(
-        contentId: int.tryParse(contentid!) ?? 0,
-        contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
-        infoName: infoname ?? '',
-        infoText: infotext ?? ''
+      contentId: int.tryParse(contentid!) ?? 0,
+      contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
+      infoName: infoname ?? '',
+      infoText: HtmlUtil().removeHtmlTags(infotext ?? ''),
     );
   }
 
   FestivalDetailInfo toFestivalDetailInfo() {
     return FestivalDetailInfo(
-        contentId: int.tryParse(contentid!) ?? 0,
-        contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
-        infoName: infoname ?? '',
-        infoText: infotext ?? ''
+      contentId: int.tryParse(contentid!) ?? 0,
+      contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
+      infoName: infoname ?? '',
+      infoText: HtmlUtil().removeHtmlTags(infotext ?? ''),
     );
   }
 
   LeportsDetailInfo toLeportsDetailInfo() {
     return LeportsDetailInfo(
-        contentId: int.tryParse(contentid!) ?? 0,
-        contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
-        infoName: infoname ?? '',
-        infoText: infotext ?? ''
+      contentId: int.tryParse(contentid!) ?? 0,
+      contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
+      infoName: infoname ?? '',
+      infoText: HtmlUtil().removeHtmlTags(infotext ?? ''),
     );
   }
 
   TouristSpotDetailInfo toTouristSpotDetailInfo() {
     return TouristSpotDetailInfo(
-        contentId: int.tryParse(contentid!) ?? 0,
-        contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
-        infoName: infoname ?? '',
-        infoText: infotext ?? ''
+      contentId: int.tryParse(contentid!) ?? 0,
+      contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
+      infoName: infoname ?? '',
+      infoText: HtmlUtil().removeHtmlTags(infotext ?? ''),
     );
   }
 }

--- a/lib/data/mapper/content_detail_mapper.dart
+++ b/lib/data/mapper/content_detail_mapper.dart
@@ -9,6 +9,8 @@ import 'package:kovel_app/domain/model/detail/restaurant/restaurant_detail.dart'
 import 'package:kovel_app/domain/model/detail/shopping/shopping_detail.dart';
 import 'package:kovel_app/domain/model/detail/tourist_spot/tourist_spot_detail.dart';
 
+import '../../core/utils/html_util.dart';
+
 extension ToContentDetail on ContentDetailDto {
   CourseDetail toCourseDetail() {
     return CourseDetail(
@@ -25,7 +27,7 @@ extension ToContentDetail on ContentDetailDto {
       contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
       infoCenter: infocenterculture ?? '',
       useFee: usefee ?? '',
-      useTime: usetime ?? '',
+      useTime: HtmlUtil().removeHtmlTags(usetime ?? ''),
       restDay: restdateculture ?? '',
       parking: parking ?? '',
       spendTime: spendtime ?? '',
@@ -56,7 +58,7 @@ extension ToContentDetail on ContentDetailDto {
       contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
       infoCenter: infocenterleports ?? '',
       restDay: restdateleports ?? '',
-      useTime: usetimeleports ?? '',
+      useTime: HtmlUtil().removeHtmlTags(usetime ?? ''),
       ageLimit: expagerangeleports ?? '',
       parking: parkingleports ?? '',
     );
@@ -67,7 +69,7 @@ extension ToContentDetail on ContentDetailDto {
       contentId: int.tryParse(contentid!) ?? 0,
       contentType: ContentType.getById(id: int.tryParse(contenttypeid!) ?? 0),
       infoCenter: infocenterlodging ?? '',
-      reservationUrl: reservationurl ?? '',
+      reservationUrl: HtmlUtil().removeHtmlTags(reservationurl ?? ''),
       roomCount: roomcount ?? '',
       isGoodStay: goodstay == "1" ? true : false,
       isBenikia: benikia == "1" ? true : false,
@@ -126,7 +128,7 @@ extension ToContentDetail on ContentDetailDto {
       expGuide: expguide ?? '',
       parking: parking ?? '',
       restDay: restdate ?? '',
-      useTime: usetime ?? '',
+      useTime: HtmlUtil().removeHtmlTags(usetime ?? ''),
     );
   }
 }

--- a/lib/data/mapper/tour_detail_mapper.dart
+++ b/lib/data/mapper/tour_detail_mapper.dart
@@ -2,6 +2,8 @@ import 'package:kovel_app/core/enums/content_type.dart';
 import 'package:kovel_app/data/dto/tour_detail_dto.dart';
 import 'package:kovel_app/domain/model/detail/tour_detail.dart';
 
+import '../../core/utils/html_util.dart';
+
 extension ToTourDetail on TourDetailDto {
   TourDetail toTourDetail() {
     return TourDetail(
@@ -21,7 +23,7 @@ extension ToTourDetail on TourDetailDto {
       imagePath: firstimage ?? '',
       tel: tel ?? '',
       telName: telname ?? '',
-      overview: overview ?? '',
+      overview: HtmlUtil().removeHtmlTags(overview ?? ''),
     );
   }
 }


### PR DESCRIPTION
### 수정 사항

- mapper 일부에 removeHtmlTags() 메서드 일부 적용 (`infoText`, `useTime`, `overview`, `reservationurl`)